### PR TITLE
Add wordcount and path fields

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "com.beachape"      %% "enumeratum-circe"                 % "1.5.14",
   "com.amazonaws"     % "amazon-kinesis-client"             % "1.7.6",
   "com.gu"            %% "content-api-client"               % "11.48",
-  "com.gu"            %% "editorial-production-metrics-lib" % "0.15-SNAPSHOT"
+  "com.gu"            %% "editorial-production-metrics-lib" % "0.16"
 )
 
 enablePlugins(JavaAppPackaging, RiffRaffArtifact)

--- a/build.sbt
+++ b/build.sbt
@@ -18,7 +18,7 @@ libraryDependencies ++= Seq(
   "io.circe"          %% "circe-generic"                    % "0.7.0",
   "com.beachape"      %% "enumeratum-circe"                 % "1.5.14",
   "com.amazonaws"     % "amazon-kinesis-client"             % "1.7.6",
-  "com.gu"            %% "content-api-client"               % "11.22",
+  "com.gu"            %% "content-api-client"               % "11.48",
   "com.gu"            %% "editorial-production-metrics-lib" % "0.15-SNAPSHOT"
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -19,7 +19,7 @@ libraryDependencies ++= Seq(
   "com.beachape"      %% "enumeratum-circe"                 % "1.5.14",
   "com.amazonaws"     % "amazon-kinesis-client"             % "1.7.6",
   "com.gu"            %% "content-api-client"               % "11.22",
-  "com.gu"            %% "editorial-production-metrics-lib" % "0.10"
+  "com.gu"            %% "editorial-production-metrics-lib" % "0.15-SNAPSHOT"
 )
 
 enablePlugins(JavaAppPackaging, RiffRaffArtifact)

--- a/src/main/scala/metricsLambdas/logic/CapiAPILogic.scala
+++ b/src/main/scala/metricsLambdas/logic/CapiAPILogic.scala
@@ -38,7 +38,8 @@ object CapiAPILogic extends Logging {
       .fromDate(timePeriod.startDate)
       .toDate(timePeriod.endDate)
       .pageSize(200)
-      .showFields("creationDate,internalComposerCode,internalOctopusCode,productionOffice,firstPublicationDate,wordCount")
+      .showFields("creationDate,internalComposerCode,internalOctopusCode,productionOffice,firstPublicationDate," +
+        "wordcount,internalCommissionedWordcount")
       .showTags("newspaper-book,tracking")
       .boolParam("show-debug", true)
     pageNumber.fold(query)(query.page(_))

--- a/src/main/scala/metricsLambdas/logic/CapiAPILogic.scala
+++ b/src/main/scala/metricsLambdas/logic/CapiAPILogic.scala
@@ -37,7 +37,7 @@ object CapiAPILogic extends Logging {
       .fromDate(timePeriod.startDate)
       .toDate(timePeriod.endDate)
       .pageSize(200)
-      .showFields("creationDate,internalComposerCode,internalOctopusCode,productionOffice,firstPublicationDate")
+      .showFields("creationDate,internalComposerCode,internalOctopusCode,productionOffice,firstPublicationDate,wordCount")
       .showTags("newspaper-book,tracking")
       .boolParam("show-debug", true)
     pageNumber.fold(query)(query.page(_))
@@ -83,6 +83,9 @@ object CapiAPILogic extends Logging {
       debugFields <- article.debug
       startingSystem = getOriginatingSystem(debugFields)
       productionOffice = fields.productionOffice.map(_.name.toLowerCase).getOrElse("")
+      wordCount = fields.wordcount
+      path = article.id
+      commissionedWordCount = None
     } yield CapiData(
         composerId = composerId,
         storyBundleId = storyBundleId,
@@ -91,7 +94,11 @@ object CapiAPILogic extends Logging {
         firstPublicationDate = publicationDate.iso8601,
         commissioningDesk = commissioningDesk,
         originatingSystem = startingSystem,
-        productionOffice = ProductionOffice.withNameOption(productionOffice))
+        productionOffice = ProductionOffice.withNameOption(productionOffice),
+        wordCount = wordCount,
+        path = path,
+        commissionedWordCount = commissionedWordCount
+      )
 
     capiData.fold[Option[KinesisEvent]]({
       log.info(s"Failed to transform CAPI article to CapiData with ID: ${article.id}")

--- a/src/main/scala/metricsLambdas/logic/CapiAPILogic.scala
+++ b/src/main/scala/metricsLambdas/logic/CapiAPILogic.scala
@@ -12,11 +12,12 @@ import io.circe.syntax._
 import metricsLambdas.Config._
 import metricsLambdas.{KinesisWriter, Logging}
 import org.joda.time.{DateTime, DateTimeZone}
+import java.time.Instant
 
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
-case class TimePeriod(startDate: DateTime, endDate: DateTime)
+case class TimePeriod(startDate: Instant, endDate: Instant)
 
 object CapiAPILogic extends Logging {
 
@@ -46,7 +47,7 @@ object CapiAPILogic extends Logging {
   private def get24HourTimePeriod: TimePeriod = {
     val endDate = new DateTime(DateTimeZone.UTC).withTimeAtStartOfDay()
     val startDate = endDate.minusDays(1)
-    TimePeriod(startDate, endDate)
+    TimePeriod(Instant.ofEpochMilli(startDate.getMillis), Instant.ofEpochMilli(endDate.getMillis))
   }
 
   private def numberOfPages: Future[Int] = client.getResponse(searchQuery()).map(_.pages)


### PR DESCRIPTION
Dates have to be posted to capi using java Instants now, there wasn't a nice way of getting a time range using the java time library so I kept the old code and just converted the dates to Instants. 
Build should pass once new version of metrics lib has been released: https://github.com/guardian/editorial-production-metrics/pull/122